### PR TITLE
修复form消息记录错误的问题

### DIFF
--- a/src/script/form/main.cpp
+++ b/src/script/form/main.cpp
@@ -77,10 +77,8 @@ std::unordered_map<std::string, FixedFunction> callbacks;
 
 TInstanceHook(void, _ZN20ServerNetworkHandler23handleModalFormResponseERK17NetworkIdentifierRK23ModalFormResponsePacket, ServerNetworkHandler,
               NetworkIdentifier const &nid, ModalFormResponsePacket &packet) {
-  CLog::info("SF","debug 1");
   auto it = callbacks.find(_getServerPlayer(nid, packet.playerSubIndex)->getXUID());
   if (it != callbacks.end()) {
-    CLog::info("SF","debug 2 %d = %d", it->second.rid, packet.id);
     if (it->second.rid == packet.id) {
       it->second(packet.data);
       callbacks.erase(it);
@@ -102,7 +100,6 @@ SCM_DEFINE_PUBLIC(c_send_form, "send-form", 3, 0, 0,
                   (scm::val<ServerPlayer *> player, scm::val<std::string> request, scm::callback<void, std::string> callback),
                   "Send form to player") {
   int id = rand();
-  CLog::info("SF","send-form generate id %d", id);
   ModalFormRequestPacket packet{ player->getClientSubId(), id, request.get() };
   auto it = callbacks.find(player->getXUID());
   if (it != callbacks.end()) callbacks.erase(it); //先删除再添加
@@ -115,7 +112,6 @@ SCM_DEFINE_PUBLIC(c_send_server_settings_form, "send-settings-form", 3, 0, 0,
                   (scm::val<ServerPlayer *> player, scm::val<std::string> request, scm::callback<void, std::string> callback),
                   "Send settings form to player") {
   int id = rand();
-  CLog::info("SF","settings_form generate id %d", id);
   ServerSettingsResponsePacket packet{ player->getClientSubId(), id, request.get() };
   auto it = callbacks.find(player->getXUID());
   if (it != callbacks.end()) callbacks.erase(it); //先删除再添加

--- a/src/script/form/main.cpp
+++ b/src/script/form/main.cpp
@@ -73,12 +73,14 @@ struct FixedFunction {
   }
 };
 
-std::unordered_map<ServerPlayer *, FixedFunction> callbacks;
+std::unordered_map<std::string, FixedFunction> callbacks;
 
 TInstanceHook(void, _ZN20ServerNetworkHandler23handleModalFormResponseERK17NetworkIdentifierRK23ModalFormResponsePacket, ServerNetworkHandler,
               NetworkIdentifier const &nid, ModalFormResponsePacket &packet) {
-  auto it = callbacks.find(_getServerPlayer(nid, packet.playerSubIndex));
+  CLog::info("SF","debug 1");
+  auto it = callbacks.find(_getServerPlayer(nid, packet.playerSubIndex)->getXUID());
   if (it != callbacks.end()) {
+    CLog::info("SF","debug 2 %d = %d", it->second.rid, packet.id);
     if (it->second.rid == packet.id) {
       it->second(packet.data);
       callbacks.erase(it);
@@ -100,8 +102,11 @@ SCM_DEFINE_PUBLIC(c_send_form, "send-form", 3, 0, 0,
                   (scm::val<ServerPlayer *> player, scm::val<std::string> request, scm::callback<void, std::string> callback),
                   "Send form to player") {
   int id = rand();
+  CLog::info("SF","send-form generate id %d", id);
   ModalFormRequestPacket packet{ player->getClientSubId(), id, request.get() };
-  callbacks.emplace(player, FixedFunction{ id, callback });
+  auto it = callbacks.find(player->getXUID());
+  if (it != callbacks.end()) callbacks.erase(it); //先删除再添加
+  callbacks.emplace(player->getXUID(), FixedFunction{ id, callback });
   player->sendNetworkPacket(packet);
   return SCM_UNSPECIFIED;
 }
@@ -110,8 +115,11 @@ SCM_DEFINE_PUBLIC(c_send_server_settings_form, "send-settings-form", 3, 0, 0,
                   (scm::val<ServerPlayer *> player, scm::val<std::string> request, scm::callback<void, std::string> callback),
                   "Send settings form to player") {
   int id = rand();
+  CLog::info("SF","settings_form generate id %d", id);
   ServerSettingsResponsePacket packet{ player->getClientSubId(), id, request.get() };
-  callbacks.emplace(player, FixedFunction{ id, callback });
+  auto it = callbacks.find(player->getXUID());
+  if (it != callbacks.end()) callbacks.erase(it); //先删除再添加
+  callbacks.emplace(player->getXUID(), FixedFunction{ id, callback });
   player->sendNetworkPacket(packet);
   return SCM_UNSPECIFIED;
 }


### PR DESCRIPTION
因有时客户端部分form未返回消息，unordered_map添加时不能复盖之前的值，导致后面的消息无法更新